### PR TITLE
fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,11 @@ recompile our files.
 Oh let's not forget to add `dist` to our `.gitignore` file.
 
 ```shell
-$ echo dist >> .gitignore
+$ touch .gitignore
+```
+
+```
+dist
 ```
 
 This will make sure we don't accidentally commit our built files to git.

--- a/README.md
+++ b/README.md
@@ -116,11 +116,8 @@ recompile our files.
 
 Oh let's not forget to add `dist` to our `.gitignore` file.
 
-```
-$ touch .gitignore
-
-```
-dist
+```shell
+$ echo dist >> .gitignore
 ```
 
 This will make sure we don't accidentally commit our built files to git.


### PR DESCRIPTION
The formatting after `.gitignore` breaks the next few sections.