### PR TITLE
Turn on sourcemaps flag for babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "start": "nodemon lib/index.js --exec babel-node --presets es2015,stage-2",
-    "build": "babel lib -d dist",
+    "build": "babel lib -d dist -s",
     "serve": "node dist/index.js",
     "test": "mocha --compilers js:babel-register"
   },


### PR DESCRIPTION
Hi guys! I was investigating on how to turn on sourcemaps support in node environment and I found one similar topic where it was pointed to use "-s" flag for source building to achieve that (https://medium.com/@Cuadraman/how-to-use-babel-for-production-5b95e7323c2f). Since your example mentioned in official babel docs, would be great to include it in the example. Noticed that using node v6.11.0.