### PR TITLE
update mocha script with babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Then we can add an `npm test` script.
     "start": "nodemon lib/index.js --exec babel-node",
     "build": "babel lib -d dist",
     "serve": "node dist/index.js",
-+   "test": "mocha --compilers js:babel-register"
++   "test": "mocha --require babel-register"
   }
 ```
 


### PR DESCRIPTION
As `--compilers` is [deprecated in mocha](https://github.com/mochajs/mocha/wiki/compilers-deprecation), they suggest to change `mocha --compilers js:babel-register` with `mocha --require babel-register`