### PR TITLE
modified 'start' script so changes to files in 'lib' trigger restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel lib -d dist",
-    "start": "npm run build && nodemon dist/index.js",
+    "start": "nodemon --watch lib --exec npm run serve",
     "serve": "npm run build && node dist/index.js",
     "test": "npm run build && mocha --require @babel/register"
   },


### PR DESCRIPTION
First of all, thank you for this example.

I'm assuming the intended behaviour for the `npm start` script is that changes to `lib/index.js` would show (after an automatic server restart) in the server running at `http://127.0.0.1:1337/`

That's the behaviour I expect, and I believe this _is_ what was intended since the README states:

> ...replace Hello World with Hello {{YOUR_NAME_HERE}} while our server is running.
> If you visit http://127.0.0.1:1337 you should see our server greeting you.

However the provided `npm start` script does not do this - changes to `lib/index.js` _are_ detected, and trigger a server restart, but no transpilation is done, so `dist/index.js` is not updated and thus changes in `lib` do not appear in the server.

I've revised the `npm start` script so that: `nodemon` explicitly watches `lib` for changes, when a change occurs `lib` is transpiled to `dist`, and then the server is restarted.